### PR TITLE
MPICH: fixes for hydra

### DIFF
--- a/libCFG_noMCW.c
+++ b/libCFG_noMCW.c
@@ -30,7 +30,7 @@ int MPIX_COMM_CREATE_FROM_GROUP(MPI_Group group, const char *tag, MPI_Comm *comm
         MPI_Group_translate_ranks(group, 1, &zero, localGroup, &localRank);
         if (MPI_UNDEFINED == localRank) {
             fprintf(stderr, "rank %d sleeping for %d seconds\n", my_wrank, 1 + my_wrank);
-            sleep(1+my_wrank); /* temporary till we do better error code return values */
+            sleep(1);
             fprintf(stderr, "rank %d looking up port using name %s\n", my_wrank, tag);
             MPI_Lookup_name(tag, MPI_INFO_NULL, port);
             fprintf(stderr, "rank %d looked up port %s using name %s\n", my_wrank, port, tag);
@@ -95,8 +95,6 @@ int main(int argc, char **argv)
         fprintf(stderr, "process %d (MPI_COMM_WORLD) now calling barrier on new_comm\n", my_wrank);
         MPI_Barrier(new_comm);
         fprintf(stderr, "process %d (MPI_COMM_WORLD) done barrier on new_comm\n", my_wrank);
-    } else {
-        sleep(20);
     }
 
     fprintf(stderr, "process %d (MPI_COMM_WORLD) now calling barrier on MPI_COMM_WORLD\n", my_wrank);

--- a/libCFG_noMCW_ac.c
+++ b/libCFG_noMCW_ac.c
@@ -36,8 +36,8 @@ int MPIX_COMM_CREATE_FROM_GROUP(MPI_Group group, const char *tag, MPI_Comm *comm
         MPI_Group_translate_ranks(group, 1, &zero, localGroup, &localRank);
         if (MPI_UNDEFINED == localRank) {
             fprintf(stderr, "rank %d sleeping for %d seconds\n", my_wrank, MY_SLEEP_DELAY);
-            sleep(MY_SLEEP_DELAY); /* temporary till we do better error code return values */
             fprintf(stderr, "rank %d looking up port using name %s\n", my_wrank, tag);
+            sleep(1);
             MPI_Lookup_name(tag, MPI_INFO_NULL, port);
             fprintf(stderr, "rank %d looked up port %s using name %s\n", my_wrank, port, tag);
         } else {
@@ -52,17 +52,17 @@ int MPIX_COMM_CREATE_FROM_GROUP(MPI_Group group, const char *tag, MPI_Comm *comm
             MPI_Group_translate_ranks(group, 1, &zero, localGroup, &localRank);
             MPI_Comm interComm;
             if (MPI_UNDEFINED == localRank) {
-                fprintf(stderr, "rank %d accepting to port %s (localSize %d)\n", my_wrank, port, localSize);
-                MPI_Comm_accept(port, MPI_INFO_NULL, 0, localComm, &interComm);
-                fprintf(stderr, "rank %d accepted using port %s (localSize %d)\n", my_wrank, port, localSize);
+                fprintf(stderr, "rank %d connecting on port %s (localSize %d)\n", my_wrank, port, localSize);
+                MPI_Comm_connect(port, MPI_INFO_NULL, 0, localComm, &interComm);
+                fprintf(stderr, "rank %d connected using port %s (localSize %d)\n", my_wrank, port, localSize);
                 MPI_Comm_free(&localComm);
                 fprintf(stderr, "rank %d merging intercomm (high group)\n", my_wrank);
                 MPI_Intercomm_merge(interComm, 1, &localComm);
                 fprintf(stderr, "rank %d merged intercomm (high group)\n", my_wrank);
             } else {
-                fprintf(stderr, "rank %d connecting on port %s (localSize %d)\n", my_wrank, port, localSize);
-                MPI_Comm_connect(port, MPI_INFO_NULL, 0, localComm, &interComm);
-                fprintf(stderr, "rank %d connected using port %s (localSize %d)\n", my_wrank, port, localSize);
+                fprintf(stderr, "rank %d accepting to port %s (localSize %d)\n", my_wrank, port, localSize);
+                MPI_Comm_accept(port, MPI_INFO_NULL, 0, localComm, &interComm);
+                fprintf(stderr, "rank %d accepted using port %s (localSize %d)\n", my_wrank, port, localSize);
                 MPI_Comm_free(&localComm);
                 fprintf(stderr, "rank %d merging intercomm (low group)\n", my_wrank);
                 MPI_Intercomm_merge(interComm, 0, &localComm);
@@ -101,8 +101,6 @@ int main(int argc, char **argv)
         fprintf(stderr, "process %d (MPI_COMM_WORLD) now calling barrier on new_comm\n", my_wrank);
         MPI_Barrier(new_comm);
         fprintf(stderr, "process %d (MPI_COMM_WORLD) done barrier on new_comm\n", my_wrank);
-    } else {
-        sleep(20);
     }
 
     fprintf(stderr, "process %d (MPI_COMM_WORLD) now calling barrier on MPI_COMM_WORLD\n", my_wrank);

--- a/libCFG_noMCW_multiport.c
+++ b/libCFG_noMCW_multiport.c
@@ -17,6 +17,7 @@ int MPIX_COMM_CREATE_FROM_GROUP(MPI_Group group, const char *tag, MPI_Comm *comm
     int groupRank, groupSize;
     int zero = 0, localRank;
     int localSize;
+    int higherRank;
     char port[MPI_MAX_PORT_NAME];
     char name[MAX_NAME_LEN];
     MPI_Comm interComm;
@@ -37,7 +38,7 @@ int MPIX_COMM_CREATE_FROM_GROUP(MPI_Group group, const char *tag, MPI_Comm *comm
     fprintf(stderr, "rank %d non-trivial use-case: target group size %d, localGroup size %d\n", my_wrank, groupSize, localSize);
 
     if (0<groupRank) {
-        int len = snprintf(name, MAX_NAME_LEN, "%s round %d", tag, groupRank);
+        int len = snprintf(name, MAX_NAME_LEN, "%sround%d", tag, groupRank);
         if (len<0 || len>=MAX_NAME_LEN) MPI_Abort(MPI_COMM_WORLD, -100);
 
         fprintf(stderr, "rank %d opening port\n", my_wrank);
@@ -69,8 +70,8 @@ int MPIX_COMM_CREATE_FROM_GROUP(MPI_Group group, const char *tag, MPI_Comm *comm
         sleep(1); // rank 0 only
     }
 
-    for (int higherRank = groupRank + 1; higherRank < groupSize; ++higherRank) {
-        int len = snprintf(name, MAX_NAME_LEN, "%s round %d", tag, higherRank);
+    for (higherRank = groupRank + 1; higherRank < groupSize; ++higherRank) {
+        int len = snprintf(name, MAX_NAME_LEN, "%sround%d", tag, higherRank);
         if (len<0 || len>=MAX_NAME_LEN) MPI_Abort(MPI_COMM_WORLD, -101);
 
         fprintf(stderr, "rank %d looking up port using name %s\n", my_wrank, name);


### PR DESCRIPTION
With these changes, it seems that within a single
host at least, mpich/hydra can run these tests without
a lot of sleeping.  There does need to be a 1 second sleep
or something for the ranks doing the name lookup esp. if
non rank zero is publishing a name

Tested with mpich pmodels/mpich@92cc3af1cff0c770bc757070d4ae35b5906b773c

and configury options: --with-pm=hydra

Signed-off-by: Howard Pritchard <hppritcha@gmail.com>